### PR TITLE
Fix English language error

### DIFF
--- a/.github/steps/4-play-time.md
+++ b/.github/steps/4-play-time.md
@@ -46,7 +46,7 @@ Adding some templates should allow any teacher to easily ask Copilot to handle c
 
 > [!IMPORTANT]
 > Working on multiple issues in parallel is an art-form. 🎨
-> Make sure you keep them independant to avoid merge conflicts! 😱
+> Make sure you keep them independent to avoid merge conflicts! 😱
 
 ### ⌨️ (optional) Activity: Try using the issue templates
 


### PR DESCRIPTION
An`independant` is a noun, but we need `independent` here :-)

### Summary

A classic English language error. Propose to fix.


### Changes
1 letter :-)


### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [V] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
