### PR TITLE
fix: endpoint path when fetching activities with queryString

### DIFF
--- a/src/backend/routers/activities.py
+++ b/src/backend/routers/activities.py
@@ -13,6 +13,7 @@ router = APIRouter(
     tags=["activities"]
 )
 
+@router.get("", response_model=Dict[str, Any])
 @router.get("/", response_model=Dict[str, Any])
 def get_activities(
     day: Optional[str] = None,

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -394,7 +394,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       const queryString =
         queryParams.length > 0 ? `?${queryParams.join("&")}` : "";
-      const response = await fetch(`/activities/${queryString}`);
+      const response = await fetch(`/activities${queryString}`);
       const activities = await response.json();
 
       // Save the activities data


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

There was a missing `/` that in my case was handled by the browser with a Temporary redirect to `activities/` 

Might be not all browsers do that, so good catch by @matthewjward 

<img width="977" height="226" alt="SCR-20250821-lhnp" src="https://github.com/user-attachments/assets/b000910e-a3d2-4fec-a578-7943ac3e8453" />

<img width="608" height="45" alt="image" src="https://github.com/user-attachments/assets/bb4e634a-e38b-464e-a73c-8014276a5fb1" />



### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/expand-your-team-with-copilot/issues/10

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
