### PR TITLE
Clarify Copilot Pro requirement and suggest manual alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ _Let Copilot coding agent tackle your issues directly on GitHub. No coding envir
 - **What you'll build**: You will provide GitHub Copilot access to the repository for the Mergington High School Extracurricular Activities website, enabling your fellow teachers to make changes without needing to code directly.
 - **Prerequisites**:
 
+  - GitHub Copilot subscription (Pro or higher) is required to use Copilot coding agent.  
+  - Optional: You can complete this exercise manually to practice the GitHub workflow without Copilot coding agent.
   - Skills exercise: [Introduction to GitHub](https://github.com/skills/introduction-to-github)
   - Skills exercise: [Getting Started with GitHub Copilot](https://github.com/skills/getting-started-with-github-copilot)
 


### PR DESCRIPTION
Hi! 👋

This PR updates the README.md to clarify that a GitHub Copilot Pro (or higher) subscription is now required to use the Copilot coding agent, since the public preview ended on June 1, 2025.

It also adds a helpful suggestion for users to optionally complete the exercise manually if they don’t have access to the coding agent — allowing them to still practice GitHub workflows.

Let me know if you'd like any tweaks! Thanks for the awesome exercise.