### PR TITLE
chore: update screenshots from deleted fork

### DIFF
--- a/.github/steps/2-collaborate.md
+++ b/.github/steps/2-collaborate.md
@@ -119,11 +119,11 @@ Now that Copilot has finished its working session, let's review its work and pro
 
 1. After a moment, Copilot will start working on your requested changes in a new agent session. Click the new **View session** button that will appear in the pull request timeline.
 
-<img width="800" alt="copilot-working-on-review" src="https://github.com/user-attachments/assets/1b83b278-e00c-4242-b315-58d226a8fcfc" />
+    <img width="800" alt="copilot-working-on-review" src="https://github.com/user-attachments/assets/076c2546-2eed-48c9-adbc-6a4edceba762" />
 
 1. As you can see, Copilot started working on the requested changes in a new session. However, the entire session journal is kept here so you can revisit logs from the previous sessions!
 
-   <img width="800"  alt="Copilot session journal with multiple sessions" src="https://github.com/user-attachments/assets/43a3325e-5f4d-48a5-a1b7-b024378596e6" />
+   <img width="800"  alt="Copilot session journal with multiple sessions" src="https://github.com/user-attachments/assets/b2debaed-65e2-4afe-9e63-e0b2ecbbb81e" />
 
 1. You can also steer Copilot mid session if you have any extra details you forgot to add initially, or you notice Copilot is heading in the wrong direction.
 

--- a/.github/steps/2-collaborate.md
+++ b/.github/steps/2-collaborate.md
@@ -12,6 +12,7 @@ Copilot provides transparency into its work through multiple channels on the pul
 
 The description will be continuously updated as Copilot progresses through its work. You can watch the description updates in real time!
 
+
 #### 🤖 Coding Agent Sessions
 
 Copilot does all work inside **sessions**. Each time you assign a task, it analyzes the problem, plans its approach, and implements changes. The first session is started immediately when Coding Agent gets assigned.
@@ -26,7 +27,7 @@ You can access the Coding Session logs in two ways:
 <details>
 <summary>📸 Copilot Session Logs </summary><br/>
 
-<img width="800" alt="screenshot of copilot coding agent session logs" src="https://github.com/user-attachments/assets/bded5d4c-e9f3-417c-ad95-30b9e13dbf3f" />
+<img width="800" alt="screenshot of copilot coding agent session logs" src="https://github.com/user-attachments/assets/2cc89771-0886-409e-a94e-6d76b07100a0" />
 
 </details>
 
@@ -81,7 +82,7 @@ flowchart LR
 
 1. The new page shows a journal of Copilot's work. On the right side, you can see the overview of the pull request being worked on live.
 
-   <img width="800" alt="screenshot of copilot coding agent session logs" src="https://github.com/user-attachments/assets/bded5d4c-e9f3-417c-ad95-30b9e13dbf3f" />
+   <img width="800" alt="screenshot of copilot coding agent session logs" src="https://github.com/user-attachments/assets/2cc89771-0886-409e-a94e-6d76b07100a0" />
 
 1. If the Copilot session is still ongoing, monitor the session journal.
 

--- a/.github/steps/4-play-time.md
+++ b/.github/steps/4-play-time.md
@@ -34,7 +34,8 @@ With the Agents panel, you can quickly assign multiple issues, track their progr
 Let's get you familiarized with the Agents panel!
 
 1. In a new tab, open the **Copilot Agents** panel from the top navigation bar
-   <img width="600" alt="Agents panel view" src="https://github.com/user-attachments/assets/d0eba779-ab37-4cf9-9229-dca8a64c119c" />
+
+   <img width="600" alt="Agents panel view" src="https://github.com/user-attachments/assets/c95a5558-a78d-41fe-bf26-25fb1d8aad52" />
 
 1. Make sure the `{{ full_repo_name }}` repository is selected in the panel and the branch is set to `main`.
 1. Assign Copilot to work on the following task:
@@ -50,13 +51,13 @@ Let's get you familiarized with the Agents panel!
 
 1. After a moment, you will notice that the task appears in the panel with its current status. You can check back here for a high level overview of all your assigned tasks.
 
-   <img width="400" alt="Agents Panel task in progress view" src="https://github.com/user-attachments/assets/0fc53085-d68d-496e-a81b-1ab78014db63" />
+   <img width="400" alt="Agents Panel task in progress view" src="https://github.com/user-attachments/assets/e80c2e39-6b2b-4d0b-9f1e-f02f41495241" />
 
 1. Click on the task to jump straight into the session logs in a new tab and track how Copilot is working on it in real time.
 
 1. You will notice Copilot begins by running the customization steps you've set up in the previous step!
 
-   <img width="600" alt="Copilot session logs with copilot setup steps" src="https://github.com/user-attachments/assets/18b6814a-c1ee-4126-a0a2-e8e82f5da424" />
+   <img width="600" alt="Copilot session logs with copilot setup steps" src="https://github.com/user-attachments/assets/4d93e2f1-9086-486d-b674-98478e16dbdf" />
 
 1. Let's leave Copilot to work its magic for now, you can come back to review the results later ✨
 
@@ -79,7 +80,7 @@ You still have some issues opened on the repository, let's see how Copilot can h
 
 1. Open the **Copilot Agents** panel again and notice that the issues you assign also appear here!
 
-   <img width="300"  alt="Copilot Agents Panel with three tasks running in parallel" src="https://github.com/user-attachments/assets/dfd77721-c736-470d-89d6-e4cad31edbd5" />
+   <img width="300"  alt="Copilot Agents Panel with three tasks running in parallel" src="https://github.com/user-attachments/assets/551a26c5-ed07-478a-9937-f1f66babd0b5" />
 
 1. For both tasks, monitor the progress in separate browser tabs. Remember you can click the **View Pull Request** button in the top right to navigate to the pull request for each task.
    > 💡 **Tip:**  You can also check the status of the task you assigned in the previous activity. Maybe Copilot is done by now?


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Previous screenshots were deleted and are not accessible - It may be because the fork was deleted

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
