### PR TITLE
fix: change image to ubuntu jammy to lower image size and fix mongod install issues

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,12 @@
 {
   "name": "Python 3",
-  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "image": "mcr.microsoft.com/devcontainers/base:jammy",
   "forwardPorts": [8000],
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.13"
+    }
+  },
   "postCreateCommand": "bash ./.devcontainer/postCreate.sh",
   "postStartCommand": "bash ./.devcontainer/postStart.sh",
   "customizations": {


### PR DESCRIPTION
Updated the devcontainer configuration to use a base image and added Python feature.

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

The change is primarily to fix the issues of setting up `mongod` in the devcontainer `postCreateCommand` that was reported on another exercise - https://github.com/skills/copilot-code-review/issues/15


### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
